### PR TITLE
Remove generated components

### DIFF
--- a/.bowerrc
+++ b/.bowerrc
@@ -1,0 +1,3 @@
+{
+  "directory": "public/bower_components"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules
+public/bower_components

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
 node_modules
-public/bower_components
+bower_components

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 node_modules
+dist
+.tmp
 bower_components

--- a/bower.json
+++ b/bower.json
@@ -1,0 +1,9 @@
+{
+  "name": "sock-puppet",
+  "version": "0.0.1",
+  "dependencies": {
+    "bootstrap": "^3.3.6",
+    "jquery": "^2.2.0",
+    "socket.io-client": "^1.4.5"
+  }
+}

--- a/package.json
+++ b/package.json
@@ -4,6 +4,7 @@
   "description": "Controlling Nodebots with SocketIO",
   "main": "server.js",
   "dependencies": {
+    "bower": "^1.7.7",
     "express": "^4.13.4",
     "johnny-five": "^0.9.21",
     "socket.io": "^1.4.5"
@@ -11,7 +12,8 @@
   "devDependencies": {},
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "start": "node server.js"
+    "start": "node server.js",
+    "postinstall": "bower install"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
I added `bower_components` to the `gitignore` (like you did with `node_modules`) since those files are generated. I added a `.bowerrc` file which is just to tell bower to put the components in `public/bower_components` instead of in the root of the project.

If you decide you don't want to deal with Bower at all at some point, you can actually install these client pages using npm and then reference them from the `node_modules` folder (future version)
